### PR TITLE
Fix: Spaces in file path

### DIFF
--- a/BetterStartPage.Control/ProjectGroupsControl.xaml.cs
+++ b/BetterStartPage.Control/ProjectGroupsControl.xaml.cs
@@ -80,7 +80,7 @@ namespace BetterStartPage.Control
         {
             if (_ide != null)
             {
-                _ide.ExecuteCommand("File.OpenProject", name);
+                _ide.ExecuteCommand("File.OpenProject", String.Format("\"{0}\"", name));
             }
         }
 
@@ -94,7 +94,7 @@ namespace BetterStartPage.Control
         {
             if (_ide != null)
             {
-                _ide.ExecuteCommand("File.OpenFile", name);
+                _ide.ExecuteCommand("File.OpenFile", String.Format("\"{0}\"", name));
             }
         }
     }


### PR DESCRIPTION
File paths should be surrounded with double quotes to handle the case when there might be spaces in the file path.

http://msdn.microsoft.com/en-us/library/16bwwbfc.aspx
