### PR TITLE
Open based on FullName, not customizable Name

### DIFF
--- a/BetterStartPage.Control/ViewModel/Project.cs
+++ b/BetterStartPage.Control/ViewModel/Project.cs
@@ -81,7 +81,7 @@ namespace BetterStartPage.Control.ViewModel
         {
             get
             {
-                var extension = Path.GetExtension(Name);
+                var extension = Path.GetExtension(FullName);
                 if (extension == null) return true;
                 if (extension.EndsWith(".sln", StringComparison.InvariantCultureIgnoreCase)) return false;
                 if (extension.EndsWith("proj", StringComparison.InvariantCultureIgnoreCase)) return false;


### PR DESCRIPTION
I think the opening of a file should be based on the full name of the file, not the customized name of the file.